### PR TITLE
fix: prevent 6th shot from bypassing limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2025-12-03
+
+Got the per-user shot limit behaving properly: the sixth post in a two-hour window is now deleted every time. The check looks at the next count (count+1) before touching the message, we return immediately on delete so the counter doesn’t drift, and when the window rolls over we start at 1 for the first shot. The DM includes the exact next allowed time. Swapped the prints in this path for the async logger so you can see the flow in the terminal and the logs channel.
+
 ## 2025-12-02
 
 - Built logging system with buffering and eeplaced print() statements with async log functions. Logs collect in a deque and flush to Discord every 60 seconds, auto-split on char limit. Logger prints to terminal + sends to Discord channel in parallel


### PR DESCRIPTION
Got the per-user shot limit behaving properly: the sixth post in a two-hour window is now deleted every time. The check looks at the next count (count+1) before touching the message, we return immediately on delete so the counter doesn’t drift, and when the window rolls over we start at 1 for the first shot. The DM includes the exact next allowed time. Swapped the prints in this path for the async logger so you can see the flow in the terminal and the logs channel.